### PR TITLE
Fixed endtag condition

### DIFF
--- a/gulp-usemin-reloaded.js
+++ b/gulp-usemin-reloaded.js
@@ -61,7 +61,7 @@ module.exports = function (options) {
                 $html
                 .each( function (i,el) {
                     if ( el.nodeName == '#comment' ) {
-                        if ( el.textContent.indexOf('end') == -1 ) {
+                        if ( el.textContent.trim().indexOf('end') == 0 ) {
                             var res = XRegExp.exec( el.textContent, rules );
                             if ( res.length ) {
                                 if ( res.action ) tmp['action'] = res.action;


### PR DESCRIPTION
The old condition would match any HTML comment with substring `'end'`. Thus, comments like this:

``` html
<!-- build:js scripts/vendor.js -->
```

would be considered an `endtag`.

This commit fixes this issue.
